### PR TITLE
Receive loop stopped on invalid packet

### DIFF
--- a/communicationhandler.go
+++ b/communicationhandler.go
@@ -133,7 +133,7 @@ func (sc *SessionContext) receiveLoop() {
 			go sc.sendLoop()
 		default:
 			fmt.Printf("ReceiveMessages: unhandled packet type: %T", pkt)
-			return
+			continue
 		}
 		// TODO: Implement the echo ping pong
 	}


### PR DESCRIPTION
When an unknown packet is received, execution should continue otherwise the receive channel wont get any further messages. Not sure what triggered the invalid packet:
```
Unknown PktType: d100
ReceiveMessages: unhandled packet type: <nil>
```
But it should definitely log that and continue processing the next ones without terminating the receiveLoop...